### PR TITLE
Handle API requests with 400 response

### DIFF
--- a/packages/api/src/api/index.js
+++ b/packages/api/src/api/index.js
@@ -3,6 +3,7 @@ import { ith, NA } from '../util/ith'
 import range from '../util/range'
 import { truncate, greaterThan } from '../util/truncate'
 import { average, category } from '../util/format'
+import sanitize from 'sanitize-html'
 
 const MAX_NAME = 36
 const MAX_GRADE = 999
@@ -20,7 +21,7 @@ const link = (id, game) => `https://ldjam.com/events/ludum-dare/${id}/${game}`
 const notFound = (id, game) => {
   return {
     title:'Game not found',
-    message:`${game} can not be found for Jam #${id}`
+    message:`${sanitize(game)} can not be found for Jam #${sanitize(id)}`
   }
 }
 
@@ -35,7 +36,7 @@ export const getData = (id, game) => {
     else if (isNaN(id)) {
       return reject({
         title: 'Invalid Ludum Dare #',
-        message: `/${id}/ is not a valid Ludum Dare Jam #`
+        message: `/${sanitize(id)}/ is not a valid Ludum Dare Jam #`
       })
     }
     get(url(id, game)).then(body => {

--- a/packages/api/src/svg/large.js
+++ b/packages/api/src/svg/large.js
@@ -33,7 +33,7 @@ export default it =>
   <text x="25" y="112" font-size="24" fill="#d0d0d8" font-weight="bold">${sanitize(it.game)}</text>
 
   <!-- Error Message -->
-  <text transform="scale(0.85, 1); translate(6, 0)" x="25" y="140" font-size="16px" font-weight="300" fill="#d0d0d8"><tspan>${sanitize(it.error || '')}</tspan></text>
+  <text transform="scale(0.85, 1); translate(6, 0)" x="25" y="140" font-size="16px" font-weight="300" fill="#d0d0d8"><tspan>${it.error || ''}</tspan></text>
 
   <!-- Logo -->
   ${!it.error ? '<a xlink:href="${it.link}" target="_blank" rel="noopener noreferrer" xlink:title="View Ludum Dare Page">' : ''}


### PR DESCRIPTION
Resolves an error where using `<` will cause the Ludum Dare
API to return a status `404` which in-turn caused a unhandled
error.