### PR TITLE
Remove un-needed install step from build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,9 @@
   "version": "1.1.0",
   "description": "SVG & PNG badges for Ludum Dare Game Jam results",
   "scripts": {
-    "build:api": "yarn install:api",
-    "build:react": "yarn install:react && yarn --cwd packages/react build",
-    "build:demo": "yarn install:demo --check-files && yarn --cwd packages/demo build",
-    "build": "NODE_ENV=production yarn build:api && yarn build:react && yarn build:demo",
+    "build:react": "yarn --cwd packages/react build",
+    "build:demo": "yarn --cwd packages/demo local && yarn --cwd packages/demo build",
+    "build": "NODE_ENV=production yarn build:react && yarn build:demo",
     "install:api": "yarn --cwd packages/api install",
     "install:react": "yarn --cwd packages/react install",
     "install:demo": "yarn --cwd packages/demo install",

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -28,6 +28,7 @@
     "build": "gatsby build && cp -r public ../../.",
     "dev": "gatsby develop",
     "start": "gatsby develop",
+    "local": "yarn add ../react ",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\"",
     "clean": "rimraf public"
   },


### PR DESCRIPTION
Removes un-needed install steps as now `yarn install` run all sub-modules